### PR TITLE
Build site on Travis after Pull Requests merged

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,9 +3,28 @@
 if [[ $TRAVIS = "true" ]]; then
 	if [[ $TRAVIS_BRANCH = "master" && $TRAVIS_PULL_REQUEST = "false" ]]; then
 		echo "Deploying!"
+
+		# Set up credentials for pushing to GitHub.  $GH_TOKEN is
+		# configured via Travis web UI.
 		git config credential.helper "store --file=.git/credentials"
 		echo "https://PyConUK-user:$GH_TOKEN@github.com" > .git/credentials
+
+		# Set up config for committing.
+		git config user.name "Travis"
+		git config user.email "no-reply@pyconuk.org"
+
+		# Add, commit, and push any changes to the output directory
+		# introduced by this change.  The output directory will have
+		# been updated if required when pre-flight-checks.sh ran.  If
+		# the output directory is already up to date then no new commit
+		# will be made.
+		git commit -a -m "Travis auto-commit.  Built latest changes."
+		git push https://PyConUK-user@github.com/PyconUK/pyconuk.org master
+
+		# Push output directory to gh-pages branch on GitHub.
 		git subtree push --prefix output https://PyConUK-user@github.com/PyconUK/pyconuk.org gh-pages
+
+		# Clean up.
 		rm .git/credentials
 	else
 		echo "Not deploying!"

--- a/pre-flight-checks.sh
+++ b/pre-flight-checks.sh
@@ -54,21 +54,6 @@ if [[ $? -eq 0 ]]; then
 	ERRORS+=("Conference name is not spelt correctly")
 fi
 
-###
-# Check that output directory is checked in.
-###
-
-if [[ $TRAVIS = "true" ]]; then
-	echo " *** Checking that output directory has been checked in."
-	# This is required, otherwise the test for git diff's exit code never fails...
-	git status
-
-	git diff --quiet output
-	if [[ $? -ne 0 ]]; then
-		ERRORS+=("Uncommitted changes in output directory")
-	fi
-fi
-
 kill $WOK_PID
 
 if [[ ${#ERRORS[@]} -eq 0 ]]; then


### PR DESCRIPTION
When building the site after commits to master (such as when a Pull
Request is merged) Travis will now commit and push any uncommitted
changes to the output directory.

This means that people need not commit their changes to the output
directory, which should:

 a) clear up some confusion with the current system, and
 b) allow the site to be edited via GitHub's web interface.

I have tested these changes at https://github.com/inglesp/deploy-test-2.
