### PR TITLE
Fix mobile menu

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -532,6 +532,7 @@ iframe {
   background: url(../img/pycon-white.png);
   background-size: cover;
   margin: 1em 1em;
+  z-index: 999;
 }
 @media all and (min-width: 560px) {
   .head h1 a {

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -538,7 +538,6 @@ iframe {
     position: absolute;
     margin: 0;
     left: 50%;
-    top: 0;
     margin-left: -3.125em;
     width: 6.25em;
     height: 12.5em;

--- a/output/abstracts/index.html
+++ b/output/abstracts/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/codeofconduct/index.html
+++ b/output/codeofconduct/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/css/main.css
+++ b/output/css/main.css
@@ -532,6 +532,7 @@ iframe {
   background: url(../img/pycon-white.png);
   background-size: cover;
   margin: 1em 1em;
+  z-index: 999;
 }
 @media all and (min-width: 560px) {
   .head h1 a {

--- a/output/css/main.css
+++ b/output/css/main.css
@@ -538,7 +538,6 @@ iframe {
     position: absolute;
     margin: 0;
     left: 50%;
-    top: 0;
     margin-left: -3.125em;
     width: 6.25em;
     height: 12.5em;

--- a/output/djangogirls/index.html
+++ b/output/djangogirls/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/education/index.html
+++ b/output/education/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/index.html
+++ b/output/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/news/index.html
+++ b/output/news/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/posters/index.html
+++ b/output/posters/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/programme/index.html
+++ b/output/programme/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/register/index.html
+++ b/output/register/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="active" class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/schedule/index.html
+++ b/output/schedule/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/science/index.html
+++ b/output/science/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/sponsorship/index.html
+++ b/output/sponsorship/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/transcode/index.html
+++ b/output/transcode/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/venue/index.html
+++ b/output/venue/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/output/volunteer/index.html
+++ b/output/volunteer/index.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 

--- a/templates/default.html
+++ b/templates/default.html
@@ -18,6 +18,7 @@
 
         <header class="head">
             <div class="wrap">
+                <h1><a href="/">PyCon UK 2015</a></h1>
                 <label class="menu-icon" for="toggle-nav">Menu</label>
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
@@ -32,7 +33,6 @@
                         <li><a{% if page.title == "Registration" %} class="active"{% endif %} class="now" href="/register/">Register</a></li>
                     </ul>
                 </nav>
-                <h1><a href="/">PyCon UK 2015</a></h1>
             </div>
         </header>
 


### PR DESCRIPTION
#### What's this PR do?

This restores the missing hamburger menu icon and nav block from the smallest viewport while maintaining the clickable area of the main PyCon icon.
#### How should this be manually tested?

Check out the `fix-mobile-menu` branch, run `make build` then navigate to `http://localhost:8000`.
- Check the PyCon icon's click area isn't covered by the nav block (it's clickable across its entire height). \* Resize your browser window to > 560 < 1000, recheck the PyCon icon isn't covered by the nav.
- Resize your browser window to < 560. Check the hamburger and menu text are visible. Open the menu and check it is in the right location.
#### Any background context you want to provide?

By moving the `<h1>` element below the `<nav>` this shifted the rest of the `<head>` elements (at the smallest viewport) up, hiding the icon and breaking the offset for the `<nav>`.
#### What are the relevant tickets?

Fixes #25 
#### Screenshots

![](http://cl.ly/image/3L3F32000j0g/Image%202015-06-17%20at%208.59.18%20pm.png)
