### PR TITLE
Programme expectations...

### DIFF
--- a/content/schedule.rst
+++ b/content/schedule.rst
@@ -41,8 +41,8 @@ and effective way.
 
 The schedule below is provisional. The skeleton will become
 increasingly fleshed out during the run up to the
-conference. Therefore, the schedule can and will change,
-even during the conference itself.
+conference. However, once decided the schedule *will NOT change except
+in extremely special circumstances*.
 
 .. _`YouTube channel`: https://www.youtube.com/channel/UChA9XP_feY1-1oSy2L7acog/videos
 .. _`Python for School Teachers`: /education/


### PR DESCRIPTION
This branch introduces a single change to manage expectations of attendees. 

I have replaced the text that suggested that the programme was a fluid ever changing affair _during the conference itself_.

Given that this has, on many a past conference, caused much pain and gnashing of teeth I suggest we promote the following stance (reflected in this pull request):

NO - THE BLOODY SCHEDULE WILL NOT CHANGE DURING THE CONFERENCE EXCEPT FOR EXTRAORDINARILY SPECIAL CIRCUMSTANCES.
