### PR TITLE
Stand alone science page

### DIFF
--- a/content/science.html
+++ b/content/science.html
@@ -17,9 +17,9 @@ body_class_hack: science
     <li><strong>Monday</strong> a collaborative <em>open science sprint</em> where you can bring along code you are working on and we will put you into teams to help improve it. Good tasks to work on might include:
     <ul>
     <li>figuring out whether Python is a good fit for your needs</li>
-    <li>speeding up code your existing code</li>
-    <li>documenting your code</li>
-    <li>adding tests to legacy code</li>
+    <li>speeding-up your code</li>
+    <li>writing developer or user documentation</li>
+    <li>adding tests to legacy programs</li>
     <li>working out how to use <a href="https://git-scm.com/">git</a> most effectively (other version control systems are available)</li>
     <li>packaging your software so that it can easily be installed </li>
     </ul>
@@ -31,7 +31,7 @@ body_class_hack: science
     <a href="http://www.nature.com/sdata/">Scientific Data</a>.
     This means that any software or figures you produce on the Monday Sprint can be given a DOI and easily shared with the scientific community.
     <br/>
-    Watch this space for more announcements -- there may even be prizes :)
+    Watch this space for more announcements - there may even be prizes :)
     </li>
 </ul>
 </p>

--- a/content/science.html
+++ b/content/science.html
@@ -3,13 +3,26 @@ slug: science
 body_class_hack: science
 ---
 
-<p>If you are a working scientist then this track is for you -- whether you have never used Python before and want to dip your toe in the water, or you are a fully-fledged Pythonista, looking to expand your repertoire. The PyCon UK Science Track will offer you three days of learning, collaboration and fun, and a chance to meet other scientists using Python.
+<p>If you are a working scientist then this track is for you - whether you have never used Python before and want to dip your toe in the water, or you are a fully-fledged Pythonista, looking to expand your repertoire. The PyCon UK Science Track will offer you three days of learning, collaboration and fun, and a chance to meet other scientists using Python.
 </p>
-<p>The PyCon UK Science Track will feature:</p>
+<p>The PyCon UK Science Track will run from Saturday 19th September - Monday 21st.
+ feature:</p>
 <ul>
-    <li>tutorials on Python suitable for beginner Python programmers where you can learn to automate common data analysis and visualisation tasks</li>
-    <li>talks from other scientists and professional software engineers on Python in science and best practices for developing your own code</li>
-    <li>a collaborative <strong>open science sprint</strong> where you can bring along a task to automate, or a piece of code you want to open source, and we will put you in groups to turn your existing scripts or workflow into an reproducible piece of open science!<br/>
+    <li><strong>Saturday</strong>
+    <ul>
+    <li>a keynote from <a href="http://www.open.ac.uk/people/ss27739">Simon Sheridan</a>, a developer on the Ptolemy instrument aboard the Rosetta space mission to comet Churyumov-Gerasimenko ('67P').</li>
+    <li><em>Tutorials</em> on Python suitable for beginner Python programmers where you can learn to automate common data analysis and visualisation tasks</li>
+    </ul>
+    <li><strong>Sunday</strong> talks from other scientists and professional software engineers on Python in science and best practices for developing your own code</li>
+    <li><strong>Monday</strong> a collaborative <em>open science sprint</em> where you can bring along code you are working on and we will put you into teams to help improve it. Good tasks to work on might include:
+    <ul>
+    <li>figuring out whether Python is a good fit for your needs</li>
+    <li>speeding up code your existing code</li>
+    <li>documenting your code</li>
+    <li>adding tests to legacy code</li>
+    <li>working out how to use <a href="https://git-scm.com/">git</a> most effectively (other version control systems are available)</li>
+    <li>packaging your software so that it can easily be installed </li>
+    </ul>
     Our friends from <a href="http://www.overleaf.com">Overleaf</a> will be joining us for this, they run a  collaborative cloud service for LaTeX users (think: Google docs for LaTeX) which has a very simple push-to-submit service for a number of Open Access journals and open science services, such as
     <a href="http://f1000research.com/contact">F1000</a>,
     <a href="http://figshare.com/">Figshare</a>,
@@ -18,16 +31,28 @@ body_class_hack: science
     <a href="http://www.nature.com/sdata/">Scientific Data</a>.
     This means that any software or figures you produce on the Monday Sprint can be given a DOI and easily shared with the scientific community.
     <br/>
-    Watch this space for more announcements -- there may be prizes :)
+    Watch this space for more announcements -- there may even be prizes :)
     </li>
 </ul>
 </p>
+<h2>Book now for just &pound;99!</h2>
+<p>
+<a href="/register">Book here</a> - just select the <strong>Scientist</strong> ticket on the registration form.
+</p>
 <h2>Open science</h2>
-<p>Why is open science so important to an libre software community like PyCon UK?
-Watch this fantastic video by Jorge Cham of <a href="http://phdcomics.com/comics.php">Piled higher and Deeper</a> to find out!
+<p>Why is open science so important to an community like PyCon UK?
+
+Python is <a href="http://www.gnu.org/philosophy/free-sw.en.html">Free software</a> which means that anyone who uses Python has a right to modify and redistribute it.
+Just like science, software is improved by having many people openly improve on the state of the art.
+Python has a reputation for being a productive language, and has had a number of <a href="https://www.python.org/about/success/#scientific">success stories</a> in science and <a href="https://www.python.org/about/success/#engineering">engineering</a>.
+At PyCon UK you will find a conference full of people who understand that <a href="http://www.software.ac.uk/policy/manifesto">Reproducible research</a> needs open, <a href="http://www.software.ac.uk/blog/2013-07-09-recomputation-manifesto">recomputable</a> software!
 </p>
 <p>
 <iframe width="420" height="315" src="https://www.youtube.com/embed/L5rVH1KGBCY" frameborder="0" allowfullscreen></iframe>
+</p>
+<h2>Keep informed</h2>
+<p>
+<iframe src="https://docs.google.com/forms/d/1IyTQzoxYQHgvXQnKCA1Nv3At_db8IzYXgJ0NTTezoyk/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 </p>
 <h2>Our sponsors</h2>
 <p>The PyCon UK Science Track has been made possible by our generous sponsors:


### PR DESCRIPTION
This PR is a step towards making the Science page more of a one-stop shop. The aim is that people pointed to the page from the SSI blog post or an email won't have to look around the site for programme or registration details. (Thanks to Jonathan Fine for nudging this forward).

It may be that we need to get in touch with Simon about the timing of his keynote before this PR is merged.

It would be good to get the talks listed here too, as soon as we can.
