### PR TITLE
Remove Sandra Binnon's name from sponsorship page

### DIFF
--- a/content/sponsorship.html
+++ b/content/sponsorship.html
@@ -213,22 +213,3 @@ Bronze (2), Supporter (1)</p>
 
 <p>To ask about sponsorship, email us at
 <a href="mailto:pyconuk-sponsorship@python.org?subject=Sponsorship enquiry">pyconuk-sponsorship@python.org</a>.</p>
-
-<h2>Sponsor's Deliveries</h2>
-
-<p>If you're having anything delivered to the conference venue,
-for example, exhibition materials or swag, then please ensure
-packages are clearly marked <strong>for PyCon UK</strong> and
-post them to:</p>
-
-<address><pre>
-    Sandra Binnion (Events Organiser),
-    PyCon UK,
-    The Innovation Centre,
-    Coventry University Technology Park,
-    Puma Way,
-    Coventry,
-    CV1 2TT.
-    United Kingdom.
-    (Telephone: +44 (0)2476 236427)
-</pre></address>


### PR DESCRIPTION
This addresses @snim2's observation in https://github.com/PyconUK/pyconuk.org/issues/29.  We can reinstate later once we have up to date details.
