### PR TITLE
Updated link to Ibis as the affiliate link.

### DIFF
--- a/content/hotels.html
+++ b/content/hotels.html
@@ -6,7 +6,7 @@ body_class_hack: venue
 <h2>Ibis</h2>
 
 <p>We have reserved 40 rooms for PyCon UK attendees at the
-<a href="http://www.accorhotels.com/gb/hotel-2793-ibis-coventry-centre/index.shtml#">Ibis Coventry Centre Hotel</a> (located about 200 meters from the
+<a href="http://www.kqzyfj.com/click-7141268-10454449?url=http%3A%2F%2Fwww.ibis.com%2Fgb%2Fhotel-2793-ibis-coventry-centre%2Findex.shtml">Ibis Coventry Centre Hotel</a> (located about 200 meters from the
 conference centre). Rooms are priced at &pound;57 per night (compared to the
 regular &pound;79 per night). Remember, we provide breakfast at the conference
 centre!</p>


### PR DESCRIPTION
This branch introduces one change:
- The link to the Ibis is now via our affiliate link which brought us untold riches (about £30) at last year's conference.

:-)
