### PR TITLE
Science schedule final

### DIFF
--- a/content/abstracts.rst
+++ b/content/abstracts.rst
@@ -145,7 +145,7 @@ software engineers on Python in the science field.
 Forming a PyCon UK research community
 -------------------------------------
 
-*Dr Sarah Mount, Wolverhampton University*
+*Sarah Mount, University of Wolverhampton*
 
 Sarah opens the Science Track by introducing the workshops, talks and
 sprint and discusses the formation of a research community.
@@ -155,7 +155,7 @@ sprint and discusses the formation of a research community.
 Accelerating Scientific Code with Numba
 ---------------------------------------
 
-*Graham Markall*
+*Graham Markall, Imperial College London*
 
 This tutorial will provide an overview of Numba, a just-in-time Python
 compiler focused on numerical computing. Originally aimed at
@@ -190,28 +190,28 @@ mechanism for installing Numba on Linux, Mac OS X and Windows.
 Getting started with testing scientific programs
 ------------------------------------------------
 
-*Martin Jones*
+*Martin Jones, University of Edinburgh*
 
 When writing programs for scientific research, we tend to be focussed
 on getting results, so testing is generally not a priority. Often,
 this means that our data-processing pipelines end up incorporating
-programs that don't have test suites. Examples of high-profile
-retractions due to software errors
-(e.g. http://www.sciencemag.org/content/314/5807/1856.full) illustrate
-the dangers of this approach.
+programs that don't have test suites. Examples of
+`high-profile retractions due to software errors <http://www.sciencemag.org/content/314/5807/1856.full>`_
+illustrate the dangers of this approach.
 
 This session will be a gentle introduction to testing, aimed at people
 writing scientific software who would like to start taking advantage
-of automated testing. We'll start with Python’s built-in tools and
-moving on to using the Nose testing framework. We’ll look at the
+of automated testing. We'll start with Python's built-in tools and
+moving on to using the Nose testing framework. We'll look at the
 problems that testing can solve, and see some best-practises for
 writing tests.
 
 The goal of this training session is for attendees to come away
-with (1) an understanding of some basic testing concepts, (2) some
-hands-on experience of running tests and interpreting the output,
-and (3) an idea of how to start applying these tools to their own
-projects.
+with:
+
+1. an understanding of some basic testing concepts,
+2. some hands-on experience of running tests and interpreting the output, and
+3. an idea of how to start applying these tools to their own projects.
 
 Attendees should have a basic knowledge of Python and should be
 familiar with the idea of functions, conditions and exceptions. They
@@ -223,14 +223,14 @@ work in most cases).
 Tit for Tat, Evolution, Game Theory and the Python Axelrod Library
 ------------------------------------------------------------------
 
-*Vince Knight*
+*Vince Knight, Cardiff University*
 
 This talk will begin with the origin of species. More precisely with a
 discussion of Darwin's theory of evolution and how Game Theory has
 been used to explain/illustrate aspects of cooperation in complex
 dynamics.
 
-In 1980, professor Robert Axelrod created a computer tournament
+In 1980, Professor Robert Axelrod created a computer tournament
 inviting submissions of code snippets that would compete against each
 other. A large amount of academic study has concentrated on the
 outcomes of this experiment. The particularity of the outcome, was
@@ -261,7 +261,7 @@ popular audience.
 Ship Data Science Products!
 ---------------------------
 
-*Ian Ozsvald*
+*Ian Ozsvald, ModelInsight.io*
 
 Building and shipping working Data Science and scientific products is
 hard - learn from 10 years of Ian's experience at ModelInsight.io to
@@ -289,7 +289,7 @@ London (ModelInsight.io).
 iCE: Interactive cloud experimentation
 --------------------------------------
 
-*George Lestaris*
+*George Lestaris, Pivotal*
 
 In the cloud-computing era, many technologies like Puppet, chef,
 ansible, etc arose to take care of setting up, maintaining and
@@ -310,7 +310,7 @@ for interactive handling of the VMs. iCE is built with
 well-established Python libraries like IPython, boto and fabric.
 
 iCE comes with a lightweight agent that registers a VM to an
-experiment’s pool. This agent will run automatically for VMs deployed
+experiment's pool. This agent will run automatically for VMs deployed
 with iCE but users can manually run it on already running VMs to
 utilise them through iCE.
 
@@ -323,16 +323,16 @@ interactiveness of single-machine SSH sessions to virtual clusters.
 Power: Python in Astronomy
 --------------------------
 
-*Tomas James*
+*Tomas James, Cardiff University*
 
 The universe is a wild and wonderful place. From the quantum
 mechanical effects that power the Sun, to the gravitational effects
 that suck everything in to a black hole, one thing links them all:
 they can all be analysed using Python.
 
-Python’s clear syntax and extensibility makes it an incredibly usable
-and streamlined language for scientists. We’ll cover off exactly how
-scientists use Python, what Python can do that other languages can’t,
+Python's clear syntax and extensibility makes it an incredibly usable
+and streamlined language for scientists. We'll cover off exactly how
+scientists use Python, what Python can do that other languages can't,
 and just how you can use a simple Python script to generate beautiful
 astronomical images from the comfort of your favourite armchair.
 
@@ -341,7 +341,7 @@ astronomical images from the comfort of your favourite armchair.
 Pythons and Earthquakes
 -----------------------
 
-*Girish Kumar*
+*Girish Kumar, Uprise Marketing*
 
 In this session, we will cover how Python is used in providing
 near-real-time maps of landslide hazard following large
@@ -354,7 +354,7 @@ a research paper was converted into a functional web application
 Getting meaning from scientific articles
 ----------------------------------------
 
-*Eleonore Mayola*
+*Eleonore Mayola, ClojureBridge*
 
 The bibliography process means every scientist regularly has to go
 through a lot of published articles in parallel to her/his
@@ -372,6 +372,45 @@ Processing to identify articles topics and train a classifier to
 distinguish between relevant and non-relevant articles depending and
 someone's area of research.
 
+.. _demo:
+
+Demo: Simple web services for scientific data
+----------------------------------------------
+
+*Alys Brett, Culham Centre for Fusion Energy*
+
+Would you like to let people access your data over the web or generate plots on
+the fly when someone loads a web page? This session will introduce the benefits
+of creating web services for accessing scientific data and let you try out the
+basics for yourself.
+
+It is now common for online companies to provide programmatic access to data -
+web APIs where data resources in many forms can be accessed via a URL. This
+approach can be very useful for scientific data too. One benefit is that you
+don't have to worry about what platforms and languages to support - the data can
+be used by anything that can make HTTP requests. You might think that creating
+this kind of web service is solely the preserve of professional engineers but,
+with the power of Python, this is changing. There are very convenient packages
+(such as Flask and Requests) that make it incredibly simple to get started.
+
+The session will start with a demonstration of some web services we've developed
+for nuclear fusion data from the JET experiment, including a plot server and a
+data browsing tool. This will be followed by a mini-tutorial to help you get
+started with harnessing the power of HTTP web services.
+
+.. _pubs:
+
+Discussion: From data to dissemination: dealing with publications
+-----------------------------------------------------------------
+
+A major theme for anyone in working research is how best to publish and
+disseminate their work. These days a wide range of tools are available to help,
+at every stage of the writing process - from great Python libraries for
+charting, to online bibliography tool and LaTeX packages to beautify your
+papers. This panel discussion will cover all aspects of dissemination work,
+and how Python can ease your publication pain.
+
+Panel members will be announced nearer the time of the conference.
 
 Lunchtime events
 ~~~~~~~~~~~~~~~~

--- a/content/schedule.rst
+++ b/content/schedule.rst
@@ -233,23 +233,29 @@ Sunday
 |       |            | Workshop   | Workshop   | Workshop   |            | Discussion | Meeting    |
 |       |            |            |            |            |            | Slot 7     | Slot 7     |
 +-------+            |            |            |            +------------+------------+------------+
-| 13:30 |            |            |            |            | Another    | BoF D      | BoF        |
-|       |            |            |            |            | Python     | Discussion | Meeting    |
-|       |            |            |            |            | for        | Slot 8     | Slot 8     |
-|       |            |            |            |            | Science    |            |            |
-|       |            |            |            |            | Talk       |            |            |
-|       |            |            |            |            |            |            |            |
-|       |            |            |            |            |            |            |            |
-|       |            |            |            |            |            |            |            |
+| 13:30 |            |            |            |            | `Demo:  \  | BoF D      | BoF        |
+|       |            |            |            |            | Simple \   | Discussion | Meeting    |
+|       |            |            |            |            | web \      | Slot 8     | Slot 8     |
+|       |            |            |            |            | services \ |            |            |
+|       |            |            |            |            | for \      |            |            |
+|       |            |            |            |            | scient\    |            |            |
+|       |            |            |            |            | ific \     |            |            |
+|       |            |            |            |            | data`_     |            |            |
 +-------+------------+------------+------------+------------+------------+------------+------------+
 | 14:00 | Plenary                                                                                  |
 +-------+------------------------------------------------------------------------------------------+
 | 14:15 | Keynote 4                                                                                |
 +-------+------------+------------+------------+------------+------------+------------+------------+
-| 15:15 | `The \     | XTalk      | XTalk      | Special    | Special    | BoF        | BoF        |
-|       | PyCon UK \ |            |            | Interest   | Interest   | Discussion | Meeting    |
-|       | Panel`_    |            |            | Group 1 or | Group 2    | Slot 9     | Slot 9     |
-|       |            |            |            | XTalk      | or XTalk   |            |            |
+| 15:15 | `The \     | XTalk      | XTalk      | Special    | `Discuss\  | BoF        | BoF        |
+|       | PyCon UK \ |            |            | Interest   | ion: \     | Discussion | Meeting    |
+|       | Panel`_    |            |            | Group 1 or | From dat\  | Slot 9     | Slot 9     |
+|       |            |            |            | XTalk      | a to diss\ |            |            |
+|       |            |            |            |            | eminatio\  |            |            |
+|       |            |            |            |            | n - \      |            |            |
+|       |            |            |            |            | dealing \  |            |            |
+|       |            |            |            |            | with \     |            |            |
+|       |            |            |            |            | publicat\  |            |            |
+|       |            |            |            |            | ions`_     |            |            |
 +-------+------------+------------+------------+------------+------------+------------+------------+
 | 16:00 | `The Lightning Talk Show`_                                                               |
 +-------+------------------------------------------------------------------------------------------+
@@ -331,3 +337,5 @@ Monday
 .. _`Power: Python in Astronomy`: /abstracts/#power
 .. _`Pythons and Earthquakes`: /abstracts/#earthquakes
 .. _`Getting meaning from scientific articles`: /abstracts/#meaning
+.. _`Demo: Simple web services for scientific data`: /abstracts/#demo
+.. _`Discussion: From data to dissemination - dealing with publications`: /abstracts/#pubs

--- a/content/science.html
+++ b/content/science.html
@@ -3,25 +3,105 @@ slug: science
 body_class_hack: science
 ---
 
-<p>If you are a working scientist then this track is for you - whether you have never used Python before and want to dip your toe in the water, or you are a fully-fledged Pythonista, looking to expand your repertoire. The PyCon UK Science Track will offer you three days of learning, collaboration and fun, and a chance to meet other scientists using Python.
+<p>If you are a working scientist, data scientist or digital humanist then this track is for you.
+Whether you have never used Python before and want to dip your toe in the water, or you are a fully-fledged Pythonista, looking to expand your repertoire, the PyCon UK Science Track will offer you three days of learning, collaboration and fun, and a chance to meet other researchers using Python.
 </p>
-<p>The PyCon UK Science Track will run from Saturday 19th September - Monday 21st.
- feature:</p>
+<p>The PyCon UK Science Track will run from Saturday 19th September - Monday 21st <a href="/register">Book now for just &pound;99</a> or learn about <a href="#sponsor">sponsorship opportunities</a>.
+
+<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Just registered for <a href="https://twitter.com/PyConUK">@PyConUK</a> - you have to do it, if only to marvel at the beautiful, non-irritating booking form</p>&mdash; Alys Brett (@alysbrett) <a href="https://twitter.com/alysbrett/status/617266875865636864">July 4, 2015</a></blockquote>
+<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+</p>
+
+<h2>Schedule</h2>
 <ul>
     <li><strong>Saturday</strong>
     <ul>
-    <li>a keynote from <a href="http://www.open.ac.uk/people/ss27739">Simon Sheridan</a>, a developer on the Ptolemy instrument aboard the Rosetta space mission to comet Churyumov-Gerasimenko ('67P').</li>
-    <li><em>Tutorials</em> on Python suitable for beginner Python programmers where you can learn to automate common data analysis and visualisation tasks</li>
+        <li><strong>Keynote</strong> from <a href="http://www.open.ac.uk/people/ss27739">Simon Sheridan</a>, a developer on the Ptolemy instrument aboard the Rosetta space mission to comet Churyumov-Gerasimenko ('67P').</li>
+        <li>
+        <strong>Track opening: Forming a PyCon UK research community</strong>
+        <em>Sarah Mount, University of Wolverhampton</em>
+        </li>
+        <li>
+        <strong>Workshop: Accelerating Scientific Code with Numba</strong>,
+        <br/><em>Graham Markall, Imperial College London</em>
+        <p>This tutorial will provide an overview of <a href="http://numba.pydata.org/">Numba</a>, a just-in-time Python compiler focused on numerical computing. Originally aimed at computations using <a href="http://www.numpy.org/">Numpy</a> arrays, it has been expanded to work with other Python types and can speed up computations that require more than just fast linear algebra operations. <a href="http://numba.pydata.org/">Numba</a> targets both CPUs and CUDA GPUs by generating native code using the LLVM compiler infrastructure.
+        </p>
+        <p>
+        This introduction aims to span the breadth of use cases rather than focusing on a single area in depth. This is in order to enable the selection of appropriate portions of code to use with <a href="http://numba.pydata.org/">Numba</a>, and the correct selection of <a href="http://numba.pydata.org/">Numba</a>'s facilities in each case.
+        </p>
+        </li>
+        <li>
+        <strong>Workshop: Getting started with testing scientific programs</strong>
+        <br/><em>Martin Jones, University of Edinburgh</em>
+        <p>
+        When writing programs for scientific research, we tend to be focussed on getting results, so testing is generally not a priority. Often, this means that our data-processing pipelines end up incorporating programs that don't have test suites. Examples of <a href="http://www.sciencemag.org/content/314/5807/1856.full">high-profile retractions due to software errors</a> illustrate the dangers of this approach.
+        </p>
+        <p>
+        This session will be a gentle introduction to testing, aimed at people writing scientific software who would like to start taking advantage of automated testing. We'll start with Python's <a href="https://docs.python.org/3/library/unittest.html">built-in tools</a> and moving on to using the <a href="https://nose.readthedocs.org/en/latest/">Nose testing framework</a>. We'll look at the problems that testing can solve, and see some best-practises for writing tests.
+        </p>
+        <p>
+        The goal of this training session is for attendees to come away with
+        <ol>
+            <li>an understanding of some basic testing concepts,</li>
+            <li>some hands-on experience of running tests and interpreting the output, and</li>
+            <li>an idea of how to start applying these tools to their own projects.</li>
+        </ol>
+        </p>
+        <p>
+        Attendees should have a basic knowledge of Python and should be familiar with the idea of functions, conditions and exceptions.
+        </p>
+        </li>
     </ul>
-    <li><strong>Sunday</strong> talks from other scientists and professional software engineers on Python in science and best practices for developing your own code</li>
+    <li><strong>Sunday</strong></li>
+    <ul>
+        <li>
+        <strong>Talk: Tit for Tat, Evolution, Game Theory and the Python Axelrod Library</strong>
+        <em>Vince Knight, Cardiff University</em>
+        <br/><a href="/abstracts#titfortat">Abstract</a>
+        </li>
+        <li>
+        <strong>Talk: Ship Data Science Products!</strong>
+        <em>Ian Ozsvald, ModelInsight.io</em>
+        <br/><a href="/abstracts#ship">Abstract</a>
+        </li>
+        <li>
+        <strong>Talk: iCE: Interactive cloud experimentation</strong>
+        <em>George Lestaris, Pivotal</em>
+        <br/><a href="/abstracts#ice">Abstract</a>
+        </li>
+        <li>
+        <strong>Talk: Power: Python in Astronomy</strong>
+        <em>Tomas James, Cardiff University</em>
+        <br/><a href="/abstracts#power">Abstract</a>
+        </li>
+        <li>
+        <strong>Talk: Pythons and Earthquakes</strong>
+        <em>Girish Kumar, Uprise Marketing</em>
+        <br/><a href="/abstracts#earthquakes">Abstract</a>
+        </li>
+        <li>
+        <strong>Talk: Getting meaning from scientific articles</strong>
+        <em>Eleonore Mayola, ClojureBridge</em>
+        <br/><a href="/abstracts#meaning">Abstract</a>
+        </li>
+        <li>
+        <strong>Demo: Simple web services for scientific data</strong>
+        <em>Alys Brett, Culham Centre for Fusion Energy</em>
+        <br/><a href="/abstracts#demo">Abstract</a>
+        </li>
+        <li>
+        <strong>Discussion: From data to dissemination: dealing with publications</strong>
+        <br/><a href="/abstracts#pubs">Abstract</a>
+        </li>
+    </ul>
     <li><strong>Monday</strong> a collaborative <em>open science sprint</em> where you can bring along code you are working on and we will put you into teams to help improve it. Good tasks to work on might include:
     <ul>
-    <li>figuring out whether Python is a good fit for your needs</li>
-    <li>speeding-up your code</li>
-    <li>writing developer or user documentation</li>
-    <li>adding tests to legacy programs</li>
-    <li>working out how to use <a href="https://git-scm.com/">git</a> most effectively (other version control systems are available)</li>
-    <li>packaging your software so that it can easily be installed </li>
+        <li>figuring out whether Python is a good fit for your needs</li>
+        <li>speeding-up your code</li>
+        <li>writing developer or user documentation</li>
+        <li>adding tests to legacy programs</li>
+        <li>working out how to use <a href="https://git-scm.com/">git</a> most effectively (other version control systems are available)</li>
+        <li>packaging your software so that it can easily be installed </li>
     </ul>
     Our friends from <a href="http://www.overleaf.com">Overleaf</a> will be joining us for this, they run a  collaborative cloud service for LaTeX users (think: Google docs for LaTeX) which has a very simple push-to-submit service for a number of Open Access journals and open science services, such as
     <a href="http://f1000research.com/contact">F1000</a>,
@@ -35,10 +115,7 @@ body_class_hack: science
     </li>
 </ul>
 </p>
-<h2>Book now for just &pound;99!</h2>
-<p>
-<a href="/register">Book here</a> - just select the <strong>Scientist</strong> ticket on the registration form.
-</p>
+
 <h2>Open science</h2>
 <p>Why is open science so important to an community like PyCon UK?
 
@@ -50,10 +127,42 @@ At PyCon UK you will find a conference full of people who understand that <a hre
 <p>
 <iframe width="420" height="315" src="https://www.youtube.com/embed/L5rVH1KGBCY" frameborder="0" allowfullscreen></iframe>
 </p>
+
+<h2>Book now for just &pound;99!</h2>
+<p>
+<a href="/register">Book here</a> - just select the <strong>Scientist</strong> ticket on the registration form.
+</p>
+
+<h2><a name="sponsor" style="text-decoration:none;">Sponsor us!</a></h2>
+<p>
+PyCon UK is a community run conference - every delegate has a paid ticket, including the volunteer organisers.
+Every year we sell out before the conference, and we are able to put on an amazing weekend of talks, workshops and fun because we have a wonderfully generous group of sponsors.
+</p>
+<p>
+2015 marks the first year that PyCon UK will run a dedicated track for researchers.
+Since PyCon UK started, we have accepted a growing number of talks from people working in the sciences and digital humanities, and we expect this trend to continue.
+Earlier this year the <a href="https://www.python.org/psf/">PSF</a> and <a href="http://numfocus.org/">NUMFocus</a> announced funding for a new <a href="https://wiki.python.org/psf/ScientificWG">working group</a>, and the future for Python in research seems more assured than ever.
+</p>
+<p>
+PyCon UK has a range of <a href="/sponsor">sponsorship options</a> for organisations who want to support this work and have access to over 300 of the most dedicated Python users in the UK.
+Sponsorship opportunities start as low as &pound;1000 for Supporter level sponsors.
+In particular, we are keen to find someone to sponsor <strong>payment relief for research students</strong>.
+Benefits to sponsors include:
+<ul>
+<li>sponsor logos will be displayed on the conference website</li>
+<li>any supplied marketing material will be included in the delegate swag bags and banners may be displayed around the conference venue</li>
+<li>All sponsors are eligible to take part, for free, in the PyCon UK recruitment event (non-sponsors will need to pay a fee of £500, in advance, to take part)</li>
+<li>In addition sponsors will be given booth space (please tell us what you have in mind for your booth)</li>
+</ul>
+If this sounds interesting to you, please email us directly on
+<a href="mailto:pyconuk-sponsorship@python.org?subject=Sponsorship enquiry">pyconuk-sponsorship@python.org</a>
+</p>
+
 <h2>Keep informed</h2>
 <p>
 <iframe src="https://docs.google.com/forms/d/1IyTQzoxYQHgvXQnKCA1Nv3At_db8IzYXgJ0NTTezoyk/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 </p>
+
 <h2>Our sponsors</h2>
 <p>The PyCon UK Science Track has been made possible by our generous sponsors:
     <ul>


### PR DESCRIPTION
This PR creates the final Science track schedule. The abstracts and schedule table have been updated. The Science Track page now contains a brief version of the full schedule (so people don't have to go hunting around the site for it).
