### PR TITLE
Ignore embedded Tweet. 

### DIFF
--- a/pre-flight-checks.sh
+++ b/pre-flight-checks.sh
@@ -48,7 +48,7 @@ fi
 
 echo " *** Checking that conference name is spelt correctly"
 
-grep -e "Pycon UK" -e "pycon UK" -e "pyconUK" -e "PyConUK" --line-number --recursive --include "*.html" output | grep -v output/science/index.html:59
+grep -e "Pycon UK" -e "pycon UK" -e "pyconUK" -e "PyConUK" --line-number --recursive --include "*.html" output | grep -v https://twitter.com/PyConUK
 
 if [[ $? -eq 0 ]]; then
 	ERRORS+=("Conference name is not spelt correctly")

--- a/pre-flight-checks.sh
+++ b/pre-flight-checks.sh
@@ -48,7 +48,7 @@ fi
 
 echo " *** Checking that conference name is spelt correctly"
 
-grep -e "Pycon UK" -e "pycon UK" -e "pyconUK" -e "PyConUK" --line-number --recursive --include "*.html" output
+grep -e "Pycon UK" -e "pycon UK" -e "pyconUK" -e "PyConUK" --line-number --recursive --include "*.html" output | grep -v output/science/index.html:59
 
 if [[ $? -eq 0 ]]; then
 	ERRORS+=("Conference name is not spelt correctly")


### PR DESCRIPTION
Tell 'grep' to ignore an embedded Tweet when checking the spelling of the conference name. Do not ignore other incorrect spelling. Fixes a bug introduced by PR #49.

Works on my machine...
