### PR TITLE
Improved formatting in Tomek's talk description

### DIFF
--- a/talks/dispelling-pytest-magic/index.html
+++ b/talks/dispelling-pytest-magic/index.html
@@ -46,20 +46,26 @@
                 <h3>Tomek Paczkowski</h3>
 <p>This short talk will look under the hood of how py.test uses assertion statement rewriting to give users a better, more pythonic testing experience. </p>
 <p>Usually in Python, assertion statements are quite simple and tedious to work with, where a simple snippet of code like this:
+<code><pre>
 def double(x):
     return x * 2
 expected = 5
-assert double(2) == expected</p>
+assert double(2) == expected
+</pre></code>
 <p>finishes with message that does not include any context:
+<code><pre>
 Traceback (most recent call last):
   File "t.py", line 5, in <module>
     assert double(2) == expected
-AssertionError</p>
+AssertionError
+</pre></code>
 <p>With py.test, we get a lot more information with all intermittent values nicely described:
+<code><pre>
 t.py:5: in <module>
     assert double(2) == expected
 E   assert 4 == 5
-E    +  where 4 = <function double at 0x1033add08>(2)</p>
+E    +  where 4 = <function double at 0x1033add08>(2)
+</pre></code>
 <p>During this talk you will learn about all the ingredients needed to reverse-engineer py.test behaviour, using import hooks described in PEP 302, and the ast module from standard library. We will try to use these hidden gems in a broader context, outside of testing.</p>
             </div>
         </div>


### PR DESCRIPTION
I've added `code` and `pre` tags so that code is displayed correctly.
