### PR TITLE
Shave a few seconds of Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: python
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+install:
+  - pip install --disable-pip-version-check --upgrade pip
+  - pip install -r requirements.txt
+
 script: bash pre-flight-checks.sh
 after_success: bash deploy.sh


### PR DESCRIPTION
- Upgrade pip so it defaults to building, caching and installing from wheels
- Configure Travis to save the pip cache after each build

The first build that checks this PR will be slightly slower, since nothing is cached yet. Subsequent builds will be faster.
