### PR TITLE
Move Science track abstracts to md. 

### DIFF
--- a/content/abstracts.rst
+++ b/content/abstracts.rst
@@ -141,16 +141,6 @@ Python for science is open to all delegates but particularly aimed at
 scientists of all kinds, data scientists, researchers and professional
 software engineers on Python in the science field.
 
-.. _form:
-
-Forming a PyCon UK research community
--------------------------------------
-
-*Sarah Mount, University of Wolverhampton*
-
-Sarah opens the Science Track by introducing the workshops, talks and
-sprint and discusses the formation of a research community.
-
 .. _numba:
 
 Accelerating Scientific Code with Numba
@@ -399,20 +389,6 @@ for nuclear fusion data from the JET experiment, including a plot server and a
 data browsing tool. This will be followed by a mini-tutorial to help you get
 started with harnessing the power of HTTP web services.
 
-.. _pubs:
-
-Discussion: From data to dissemination: dealing with publications
------------------------------------------------------------------
-
-A major theme for anyone in working research is how best to publish and
-disseminate their work. These days a wide range of tools are available to help,
-at every stage of the writing process - from great Python libraries for
-charting, to online bibliography tool and LaTeX packages to beautify your
-papers. This panel discussion will cover all aspects of dissemination work,
-and how Python can ease your publication pain.
-
-Panel members will be announced nearer the time of the conference.
-
 Lunchtime events
 ~~~~~~~~~~~~~~~~
 
@@ -490,14 +466,4 @@ patch with documentation, and submitting it.
 
 Read more here: http://dont-be-afraid-to-commit.readthedocs.org
 
-.. _sciencesprint:
 
-Python for Science Sprint
--------------------------
-
-Collaborative open science sprint where you can bring along a task to
-automate, or a piece of code you want to open source, and we will help
-you find others to form a small group to turn your existing scripts or
-workflow into an reproducible piece of open science!
-
-Read more here: http://www.pyconuk.org/science/

--- a/content/panels/dealing-with-publications.md
+++ b/content/panels/dealing-with-publications.md
@@ -1,0 +1,17 @@
+type: session
+title: "Discussion: From data to dissemination: dealing with publications"
+slug: "dealing-with-publications"
+url: "panels/dealing-with-publications/index.html"
+body_class_hack: talks
+---
+
+### Discussion: From data to dissemination: dealing with publications
+
+A major theme for anyone in working research is how best to publish and
+disseminate their work. These days a wide range of tools are available to help,
+at every stage of the writing process - from great Python libraries for
+charting, to online bibliography tool and LaTeX packages to beautify your
+papers. This panel discussion will cover all aspects of dissemination work,
+and how Python can ease your publication pain.
+
+Panel members will be announced nearer the time of the conference.

--- a/content/schedule.rst
+++ b/content/schedule.rst
@@ -475,17 +475,17 @@ Notes
 .. _`psf reception`: /abstracts/#psf
 .. _`The Non-Closing Closing`: /abstracts/#nonclosing
 .. _`Lightning PyKids UK`: /abstracts/#lightningkids
-.. _`forming a pycon uk research community`: /abstracts/#form
-.. _`accelerating scientific code with numba`: /abstracts/#numba
-.. _`getting started with testing scientific programs`: /abstracts/#testing
-.. _`tit for tat, evolution, game theory and the python axelrod library`: /abstracts/#titfortat
-.. _`ship data science products!`: /abstracts/#ship
-.. _`ice: interactive cloud experimentation`: /abstracts/#ice
-.. _`Power: Python in Astronomy`: /abstracts/#power
-.. _`Pythons and Earthquakes`: /abstracts/#earthquakes
-.. _`Getting meaning from scientific articles`: /abstracts/#meaning
-.. _`Demo: Simple web services for scientific data`: /abstracts/#demo
-.. _`Discussion: From data to dissemination - dealing with publications`: /abstracts/#pubs
+.. _`forming a pycon uk research community`: /talks/forming-a-research-community/
+.. _`accelerating scientific code with numba`: /workshops/accelerating-scientific-code-with-numba/
+.. _`getting started with testing scientific programs`: /workshops/getting-started-with-testing-scientific-programs/
+.. _`tit for tat, evolution, game theory and the python axelrod library`: /talks/tit-for-tat-evolution-game-theory-and-the-python-axelrod-library/
+.. _`ship data science products!`: /talks/ship-data-science-products/
+.. _`ice: interactive cloud experimentation`: /talks/ice-interactive-cloud-experimentation/
+.. _`Power: Python in Astronomy`: /talks/power-python-in-astronomy/
+.. _`Pythons and Earthquakes`: /talks/pythons-and-earthquakes/
+.. _`Getting meaning from scientific articles`: /talks/getting-meaning-from-scientific-articles/
+.. _`Demo: Simple web services for scientific data`: /demos/simple-web-services-for-scientific-data/
+.. _`Discussion: From data to dissemination - dealing with publications`: /panels/dealing-with-publications/
 .. _`Python's Infamous GIL`: /talks/pythons-infamous-gil/
 .. _`Analyzing Python with Pylint`: /talks/analyzing-python-with-pylint/
 .. _`managing mocks - the how why and when of mocking in python`: /talks/managing-mocks-the-how-why-and-when-of-mocking-in-python/
@@ -548,7 +548,7 @@ Notes
 .. _`Building Async Microservices`: /workshops/building-async-microservices/
 .. _`Scrapy Workshop`: /workshops/scrapy-workshop/
 .. _`single board computer hackspace`: /abstracts/#singleboard
-.. _`python for science sprint`: /abstracts/#sciencesprint
+.. _`python for science sprint`: /sprints/open-science-sprint/
 .. _`don't be afraid to commit`: /abstracts/#commitsprint
 .. _`code clinic`: /abstracts/#codeclinic
 .. _`DjangoGirls`: /djangogirls/

--- a/content/science.html
+++ b/content/science.html
@@ -90,10 +90,10 @@ Whether you have never used Python before and want to dip your toe in the water,
         <em>Alys Brett, Culham Centre for Fusion Energy</em>
         </li>
         <li>
-        <strong>Discussion: From data to dissemination: dealing with publications</strong>
+        <strong><a href="/panels/dealing-with-publications/">Discussion: From data to dissemination: dealing with publications</a></strong>
         </li>
     </ul>
-    <li><strong>Monday</strong> a collaborative <em>open science sprint</em> where you can bring along code you are working on and we will put you into teams to help improve it. Good tasks to work on might include:
+    <li><strong>Monday</strong> <a href="/sprints/open-science-sprint/">a collaborative <em>open science sprint</em></a> where you can bring along code you are working on and we will put you into teams to help improve it. Good tasks to work on might include:
     <ul>
         <li>figuring out whether Python is a good fit for your needs</li>
         <li>speeding-up your code</li>

--- a/content/sprints/open-science-sprint.md
+++ b/content/sprints/open-science-sprint.md
@@ -1,0 +1,35 @@
+type: session
+title: "Sprint: Open Science"
+slug: "open-science-sprint"
+url: "sprints/open-science-sprint/index.html"
+body_class_hack: talks
+---
+
+### Open science sprint
+
+Collaborative open science sprint where you can bring along a task to
+automate, or a piece of code you want to open source, and we will help
+you find others to form a small group to turn your existing scripts or
+workflow into an reproducible piece of open science!
+
+Good tasks to work on might include:
+
+* figuring out whether Python is a good fit for your needs
+* speeding-up your code
+* writing developer or user documentation
+* adding tests to legacy programs
+* working out how to use [git](https://git-scm.com/) most effectively (other version control systems are available)
+* packaging your software so that it can easily be installed
+
+
+Our friends from [Overleaf](http://www.overleaf.com) will be joining us for this, they run a  collaborative cloud service for LaTeX users (think: Google docs for LaTeX) which has a very simple push-to-submit service for a number of Open Access journals and open science services, such as
+
+* [F1000](http://f1000research.com/contact)
+* [Figshare](http://figshare.com/)
+* [PeerJ](https://peerj.com/)
+* [arXiv](http://arxiv.org/) and
+* [Scientific Data](http://www.nature.com/sdata/).
+
+This means that any software or figures you produce on the Monday Sprint can be given a DOI and easily shared with the scientific community.
+
+Watch this space for more announcements - there <s>may even</s> **will** be prizes :)

--- a/content/talks/forming-a-research-community.md
+++ b/content/talks/forming-a-research-community.md
@@ -1,0 +1,13 @@
+type: session
+title: "Forming a PyCon UK research community"
+slug: "forming-a-research-community"
+url: "talks/forming-a-research-community/index.html"
+body_class_hack: talks
+---
+
+### Forming a PyCon UK research community
+
+*Sarah Mount, University of Wolverhampton*
+
+Sarah opens the Science Track by introducing the workshops, talks and
+sprint and discusses the formation of a research community.


### PR DESCRIPTION
This removes all links from Science track items in the schedule to `content/abstracts.rst` and replaces them with links to individual markdown files. This is more consistent with the rest of the site and avoids repetition. Also, some speakers have made improvements to their abstracts, so we don't want the old abstracts in `content/abstracts.rst` hanging around.
