### PR TITLE
Match formatting of Sarah's talk abstract to others

### DIFF
--- a/content/talks/forming-a-research-community.md
+++ b/content/talks/forming-a-research-community.md
@@ -5,9 +5,7 @@ url: "talks/forming-a-research-community/index.html"
 body_class_hack: talks
 ---
 
-### Forming a PyCon UK research community
-
-*Sarah Mount, University of Wolverhampton*
+### Sarah Mount, University of Wolverhampton
 
 Sarah opens the Science Track by introducing the workshops, talks and
 sprint and discusses the formation of a research community.


### PR DESCRIPTION
All the talks had the author as an h3 heading, except this one.
The talk title is already provided in the metadata, & rendered.
