### PR TITLE
Replace embedded OpenStreetMap with MapBox

### DIFF
--- a/content/venue.html
+++ b/content/venue.html
@@ -15,8 +15,9 @@ body_class_hack: venue
 <p>
     The venue is located conveniently, 10 minutes' walk from Coventry Railway Station, close to the UK motorway network and with good car parking facilities (see below), and with <a href="/hotels">Hotel Accommodation</a> onsite.
 </p>
-
-<iframe width="100%" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://www.openstreetmap.org/export/embed.html?bbox=-1.5059745311737058%2C52.399833211725685%2C-1.5017688274383545%2C52.40604509180987&amp;layer=mapnik&amp;marker=52.40293598823974%2C-1.5038716793060303" style="border: none"></iframe>
+<iframe width='100%' height='350' frameBorder='0'
+    src='https://a.tiles.mapbox.com/v4/moreati.10138cdf/attribution,zoompan,zoomwheel.html?access_token=pk.eyJ1IjoibW9yZWF0aSIsImEiOiI3ZmM0YTYyYTllYTcxNGJiZGE1MDZkYTFhYTQ4ZjVmMiJ9.tNVfHzR8DHS1CKUVPlf_AA#16/52.403/-1.505'
+    ></iframe>
 
 <h2>What you are looking for</h2>
 <p>This is the TechnoCentre main entrance, on the day you should see some PyCon UK signs.</p>
@@ -35,7 +36,7 @@ body_class_hack: venue
     <li>Turn right then left into the Ibis car park entrance, and walk through into the car park with the Formule 1 hotel opposite you. (If you are cheeky you could just walk through the Ibis hotel lobby after crossing Mile Lane.)</li>
     <li>Turn right and walk through the car park, then into the TechnoCentre car park.</li>
     <li>Walk to the end of the TechnoCentre car park, then bear right around the end of the building to the main entrance.</li>
-    <li>If you zoom in on the OpenStreetMap page you will see all these landmarks.</li>
+    <li>If you zoom in on the map you will see all these landmarks.</li>
 </ol>
 <p>Time: <strong>9 minutes</strong>.</p>
 <p>Check out a <a href="http://tinyurl.com/coventry-station-to-venue">flickr photostream of the route</a> with slightly less serious comments...</p>


### PR DESCRIPTION
I'm bike-shedding, feel free to ignore or reject this.

I find the default OSM map theme at http://pyconuk.org/venue overpowering. It squeezes in too much detail, making it harder to show the bits we want.

I made a [custom map](https://api.mapbox.com/v4/moreati.10138cdf/page.html?access_token=pk.eyJ1IjoibW9yZWF0aSIsImEiOiI3ZmM0YTYyYTllYTcxNGJiZGE1MDZkYTFhYTQ4ZjVmMiJ9.tNVfHzR8DHS1CKUVPlf_AA#17/52.40251/-1.50771) using https://mapbox.com who derive their mapping from OSM. I chose a less colourful, spartan base layer, and I was able add multiple markers.

![image](https://cloud.githubusercontent.com/assets/174450/9488660/6f479f26-4bd3-11e5-857f-b11b88f61e02.png)

Possible downsides:
- The free tier allows 50 000 map views/month. We probably won't hit that, but it's possible.
