### PR TITLE
Render a flat schedule, in addition to the tabular

### DIFF
--- a/hooks/__hooks__.py
+++ b/hooks/__hooks__.py
@@ -8,5 +8,5 @@ import flat_schedule
 # The `hooks` dictionary that wok will import
 # See http://wok.mythmon.com/docs/hooks/
 hooks = {
-    'site.done': [flat_schedule.write_flat_schedule],
+    'site.done': [flat_schedule.create_flat_schedule],
     }

--- a/hooks/__hooks__.py
+++ b/hooks/__hooks__.py
@@ -1,0 +1,12 @@
+''' __hooks__.py
+
+Attach Python functions to wok hooks.
+'''
+
+import flat_schedule
+
+# The `hooks` dictionary that wok will import
+# See http://wok.mythmon.com/docs/hooks/
+hooks = {
+    'site.done': [flat_schedule.write_flat_schedule],
+    }

--- a/hooks/flat_schedule.py
+++ b/hooks/flat_schedule.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+
+import datetime
+import io
+import itertools
+import os
+import re
+
+import docutils.examples
+import jinja2
+import lxml.html
+#import yaml
+
+
+def parse_date(s):
+    """Returns a datetime.date, from a date in the tabular schedule
+
+    >>> parse_date('Friday 18th September 2015')
+    datetime.date(2015, 9, 18)
+    """
+    m = re.match(r"""
+        (?P<dayname>    [A-Za-z]+)
+        \s
+        (?P<day>        [0-9]+)
+        [a-z]{0,2} # Discard any suffix, e.g. th, st
+        \s
+        (?P<monthname>  [A-Za-z]+)
+        \s
+        (?P<year>       [0-9]+)
+        """,
+        s, re.VERBOSE,
+        )
+    s = '{day} {monthname} {year}'.format(**m.groupdict())
+    return datetime.datetime.strptime(s, '%d %B %Y').date()
+
+
+def parse_time(s):
+    """Returns a datetime.time, from an event time in the tabular schedule
+    """
+    return datetime.datetime.strptime(s, '%H:%M').time()
+
+
+def parse_days(tree):
+    """Yields (day, table) for each day covered by the tabular schedule
+    """
+    for section in tree.xpath('.//div[@class="section"]'):
+        day = section.find('./h1').text
+        table = section.find('./table')
+        if day is not None and table is not None:
+            day = parse_date(day)
+            yield day, table
+
+
+def collapse_whitespace(s):
+    """Strips surrounding whitespace & repeated spaces from s
+    """
+    return re.sub(r' ', ' ', s.strip())
+
+
+def iter_cells(cells):
+    """Yields td or th elements, repeating them as necessary for colspan=n
+    """
+    for cell in cells:
+        colspan = int(cell.get('colspan', 1))
+        for i in xrange(colspan):
+            yield cell
+
+
+def parse_rooms(table):
+    """Yields the rooms used in a single schedule table
+    """
+    row1 = iter_cells(table.xpath('./thead/tr[1]/th')[1:])
+    row2 = iter_cells(table.xpath('./thead/tr[2]/th')[1:])
+    for th1, th2 in itertools.izip_longest(row1, row2):
+        text1 = collapse_whitespace(th1.text)
+        text2 = collapse_whitespace(th2.text) if th2 is not None else ''
+        if text2:
+            yield '%s (%s)' % (text1, text2)
+        else:
+            yield text1
+
+
+def parse_speaker(href):
+    """Returns the speaker of a event, parsed from the Markdown abstract
+    """
+    m = re.match(r'/talks/(?P<slug>[a-z0-9-]+)/', href)
+    if not m:
+        return None
+    try:
+        path = 'content/talks/{}.md'.format(m.group('slug'))
+    except:
+        print repr(href), m.groupdict()
+        raise
+    try:
+        with io.open(path, encoding='utf-8') as f:
+            markdown = f.read(1024)
+    except IOError:
+        return None
+    m = re.search(
+        r'^### +?(?P<speaker>[\w][^\n]+?)\n',
+        markdown,
+        re.UNICODE | re.MULTILINE,
+        )
+    if m:
+        return m.group('speaker')
+
+
+def parse_event(td):
+    """Returns the details of an event, parsed from a table cell
+    """
+    a = td.find('./a')
+    elem = a if a is not None else td
+    href = elem.get('href')
+    if href is not None:
+        speaker = parse_speaker(href)
+    else:
+        speaker = None
+    if elem.text is not None:
+        title = collapse_whitespace(elem.text)
+    else:
+        title = None
+    return href, title, speaker
+
+
+def events(table):
+    """Yields event dicts parsed from a single schedule table
+    """
+    rooms = [room for room in parse_rooms(table)]
+    trs = [tr for tr in table.xpath('./tbody/tr')
+           if tr.find('./td').text != u'\N{NO-BREAK SPACE}']
+    times = [parse_time(tr.find('./td').text) for tr in trs]
+
+    for i, (start_time, tr) in enumerate(zip(times, trs)):
+        tds = tr.xpath('./td')[1:]
+        j = 0
+        for td in tds:
+            room = rooms[j]
+            rowspan = int(td.get('rowspan', 1))
+            colspan = int(td.get('colspan', 1))
+            try:
+                finish_time = times[i+rowspan]
+            except IndexError:
+                finish_time = None
+            href, title, speaker = parse_event(td)
+            if title:
+                yield {
+                    'start': start_time,
+                    'finish': finish_time,
+                    'href': href,
+                    'location': room,
+                    'title': title,
+                    'speaker': speaker,
+                    }
+            j += colspan
+
+
+def parse_tabular_schedule(tree):
+    """Yields event dicts, parsed from the tabular schedule
+    """
+    for day, table in parse_days(tree):
+        for event in events(table):
+            event['day'] = day
+            event['start'] = datetime.datetime.combine(day, event['start'])
+
+            if event['finish'] is not None:
+                event['finish'] = datetime.datetime.combine(day, event['finish'])
+                event['duration'] = event['finish'] - event['start']
+            yield event
+
+
+def days_hours_minutes_seconds(td):
+    """Returns a tuple for the number of (days, hours, minutes, seconds) in a
+    `datetime.timedelta`.
+
+    >>> days_hours_minutes_seconds(datetime.timedelta(seconds=5400))
+    (0, 1, 30, 0)
+    """
+    hours, remainder = divmod(td.seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return (td.days, hours, minutes, seconds)
+
+
+def format_duration(duration, sep=' ', units='dhms', default='0s'):
+    """Returns a minimal string, representing a `datetime.timedelta`
+
+    >>> format_duration(datetime.timedelta(seconds=5400))
+    '1h 30m'
+    """
+    qtys = days_hours_minutes_seconds(duration)
+    result = ('%i%s' % (qty, unit) for qty, unit in zip(qtys, units) if qty)
+    return sep.join(result) or default
+
+
+def ordinal_suffix(i, default='th'):
+    """Returns the appropriate suffix for an integer i
+    """
+    suffixes = {1:'st', 2:'nd', 3:'rd',
+                11:'th', 12:'th', 13:'th'}
+    if i in suffixes:
+        return suffixes[i]
+    elif i % 100 in suffixes:
+        return suffixes[i % 100]
+    elif i % 10 in suffixes:
+        return suffixes[i % 10]
+    return default
+
+
+def format_day_id(day):
+    """Returns a string matching the id made from schedule.rst by docutils
+
+    >>> format_day_id(datetime.datetime(2015, 9, 18))
+    'friday-18th-september-2015'
+    """
+    date_format = '%A-%d{suffix}-%B-%Y'.format(suffix=ordinal_suffix(day.day))
+    return day.strftime(date_format).lower()
+
+
+def render_schedule(schedule, template_dir):
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(template_dir),
+        autoescape=True,
+        lstrip_blocks=True,
+        trim_blocks=True,
+        )
+    env.filters.update({
+        'ordinal_suffix': ordinal_suffix,
+        'days_hours_minutes_seconds': days_hours_minutes_seconds,
+        'format_day_id': format_day_id,
+        'format_duration': format_duration,
+        })
+
+    templ = env.get_template('flat_schedule.html')
+    html = templ.render({
+        'page': {
+            'title': 'Schedule',
+            'slug': 'schedule',
+            'body_class_hack': 'talks',
+            },
+        'schedule': schedule,
+        })
+    return html
+
+
+def write_flat_schedule(config):
+    schedule_dir = os.path.join(config['output_dir'], 'schedule')
+    tab_sched_path = os.path.join(schedule_dir, 'index.html')
+    tab_sched_etree = lxml.html.parse(tab_sched_path)
+
+    schedule = parse_tabular_schedule(tab_sched_etree)
+    schedule_html = render_schedule(schedule, config['template_dir'])
+
+    schedule_path = os.path.join(schedule_dir, 'flat.html')
+    with io.open(schedule_path, 'w', encoding='utf-8') as f:
+        f.write(schedule_html)
+
+
+if __name__ == '__main__':
+    # Get the html of the tabular schedule
+    sched_rst = io.open('content/schedule.rst', encoding='utf-8').read()
+    sched_rst = sched_rst.split('---\n', 1)[1]
+    sched_html = docutils.examples.html_body(sched_rst)
+
+    # Parse the html of the tabular schedule 
+    sched_etree = lxml.html.fromstring(sched_html)
+    schedule = parse_tabular_schedule(sched_etree)
+
+    with io.open('flat_schedule.html', 'w', encoding='utf-8') as f:
+        f.write(html)

--- a/hooks/flat_schedule.py
+++ b/hooks/flat_schedule.py
@@ -164,7 +164,7 @@ def stringify_children(node):
                                       ))
              + [node.tail])
     # filter removes possible Nones in texts and tails
-    return ''.join(part.strip() for part in parts if part is not None)
+    return ''.join(part for part in parts if part is not None)
 
 
 def events(table):

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -784,3 +784,47 @@ iframe {
 .sponsors img.wide-logo {
   width: 480px;
 }
+
+/* FLAT SCHEDULE */
+summary h2.day {
+    display: inline-block;
+    margin-top: 1em;
+}
+summary {cursor: pointer;}
+
+.schedule {
+    margin-left: 1em;
+    width: 90%;
+}
+
+.schedule tbody {
+    border-bottom: 1px solid #E1E1E1;
+    border-top: 1px solid #E1E1E1;
+}
+
+.schedule td,
+.schedule th {
+    border: none;
+    padding: 8px 0px 8px 8px;
+    vertical-align: top;
+}
+
+.schedule p.first,
+.docutils p.first {
+    margin-top: 0;
+}
+
+.event .duration,
+.event .speaker,
+.event .type,
+.event .location {
+    font-size: 0.8em;
+    color: #707070;
+}
+
+.event .filler {
+    font-size: 0.8em;
+    color: #909090;
+    padding-left: 0.2em;
+    padding-right: 0.2em;
+}

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -805,13 +805,33 @@ summary {cursor: pointer;}
 .schedule td,
 .schedule th {
     border: none;
-    padding: 8px 0px 8px 8px;
+    padding: 8px 8px 8px 8px;
+    line-height: 1.1;
     vertical-align: top;
+}
+.schedule tr:first-child td,
+.schedule tr:first-child th {
+    padding-top: 16px;
+}
+
+.schedule tr:last-child td,
+.schedule tr:last-child th {
+    padding-bottom: 16px;
 }
 
 .schedule p.first,
 .docutils p.first {
     margin-top: 0;
+}
+
+.start {
+    float: right;
+    font-weight: normal;
+    font-size: 1.5em;
+}
+.start .minute {
+    vertical-align: text-top;
+    font-size: 0.7em;
 }
 
 .event .duration,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 awesome-slugify==1.4
 docutils==0.8.1
-Jinja2==2.6
+Jinja2==2.7.3
 LinkChecker==9.3
+lxml==3.4.4
 Markdown==2.1.1
 py==1.4.27
 Pygments==1.4

--- a/templates/flat_schedule.html
+++ b/templates/flat_schedule.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="intro">
+    <div class="column_intro">
+        <div class="textblock">
+            <h1 class="huge">{{ page.title }}</h1>
+        </div>
+    </div>
+</div>
+
+<article class="main-article">
+    <div class="content">
+        <div class="column_content">
+            <div class="textblock">
+
+<style>
+h2.day {
+    display: inline-block;
+    margin-top: 1em;
+}
+summary {cursor: pointer;}
+summary:focus {outline: none;}
+
+table.schedule {
+    margin-left: 1em;
+    width: 90%;
+}
+table.schedule tbody {
+    border-bottom: 1px solid #E1E1E1;
+    border-top: 1px solid #E1E1E1;
+}
+table.schedule td,
+table.schedule th {
+    border: none;
+    padding: 8px 0px 8px 8px;
+    vertical-align: top;
+}
+.title,
+.speaker {
+    display: block;
+}
+.start,
+.speaker,
+.duration,
+.location {
+    font-size: 0.8em;
+    color: #707070;
+}
+</style>
+{% for day, events in schedule|groupby('day') %}
+<details class=day open>
+    <summary>
+        <h2 class=day id="{{day|format_day_id}}">{{ day.strftime('%A') }}</h2>
+    </summary>
+    <table class=schedule>
+        {% for start, events in events|groupby('start') %}
+        <tbody>
+            {% for ev in events %}
+            <tr>
+                {% if loop.first %}
+                <td rowspan="{{loop.length}}">
+                    <time class=start datetime="{{start}}">
+                        {{ start.strftime('%H:%M') }}
+                    </time>
+                </th>
+                {% endif %}
+                <td class=event>
+                    {% if ev.href %}
+                    <span class=title><a href="{{ev.href}}">{{ ev.title }}</a></span>
+                    {% else %}
+                    <span class=title>{{ ev.title }}</span>
+                    {% endif %}
+                    {% if ev.speaker %}
+                    <span class=speaker>{{ev.speaker}}</span>
+                    {% endif %}
+                    {% if ev.duration %}
+                    <time class=duration>{{ ev.duration|format_duration }}</time>
+                    {% endif %}
+                    <span class=location>{{ ev.location }}</span>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        {% endfor %}
+    </table>
+</details>
+{% endfor %}
+            </div>
+        </div>
+    </div>
+</article>
+{% endblock content %}

--- a/templates/flat_schedule.html
+++ b/templates/flat_schedule.html
@@ -14,40 +14,11 @@
         <div class="column_content">
             <div class="textblock">
 
-<style>
-h2.day {
-    display: inline-block;
-    margin-top: 1em;
-}
-summary {cursor: pointer;}
-summary:focus {outline: none;}
-
-table.schedule {
-    margin-left: 1em;
-    width: 90%;
-}
-table.schedule tbody {
-    border-bottom: 1px solid #E1E1E1;
-    border-top: 1px solid #E1E1E1;
-}
-table.schedule td,
-table.schedule th {
-    border: none;
-    padding: 8px 0px 8px 8px;
-    vertical-align: top;
-}
-.title,
-.speaker {
-    display: block;
-}
-.start,
-.speaker,
-.duration,
-.location {
-    font-size: 0.8em;
-    color: #707070;
-}
-</style>
+<p>Jump to
+{% for day, events in schedule|groupby('day') %}
+<a href="#{{day|format_day_id}}">{{ day.strftime('%A') }}</a>&ensp;
+{% endfor %}
+</p>
 {% for day, events in schedule|groupby('day') %}
 <details class=day open>
     <summary>
@@ -65,17 +36,22 @@ table.schedule th {
                     </time>
                 </th>
                 {% endif %}
-                <td class=event>
-                    {% if ev.href %}
-                    <span class=title><a href="{{ev.href}}">{{ ev.title }}</a></span>
-                    {% else %}
-                    <span class=title>{{ ev.title }}</span>
-                    {% endif %}
-                    {% if ev.speaker %}
-                    <span class=speaker>{{ev.speaker}}</span>
-                    {% endif %}
+                <td class="event {{ev.type or ''}}">
+                    <div class=title>{{ ev.rawhtml|safe }}</div>
+                    <div>
+                        {% if ev.type %}
+                        <span class=type>{{ ev.type.title() }}</span>
+                        {% endif %}
+                        {% if ev.type and ev.speaker %}
+                        <span class=filler>by</span>
+                        {% endif %}
+                        {% if ev.speaker %}
+                        <span class=speaker>{{ev.speaker}}</span>
+                        {% endif %}
+                    </div>
                     {% if ev.duration %}
                     <time class=duration>{{ ev.duration|format_duration }}</time>
+                    <span class=filler>in</span>
                     {% endif %}
                     <span class=location>{{ ev.location }}</span>
                 </td>
@@ -86,6 +62,14 @@ table.schedule th {
     </table>
 </details>
 {% endfor %}
+
+<p>Back to
+{% for day, events in schedule|groupby('day') %}
+&emsp;
+<a href="#{{day|format_day_id}}">{{ day.strftime('%A') }}</a>&ensp;
+{% endfor %}
+</p>
+
             </div>
         </div>
     </div>

--- a/templates/flat_schedule.html
+++ b/templates/flat_schedule.html
@@ -30,9 +30,9 @@
             {% for ev in events %}
             <tr>
                 {% if loop.first %}
-                <td rowspan="{{loop.length}}">
+                <th rowspan="{{loop.length}}">
                     <time class=start datetime="{{start}}">
-                        {{ start.strftime('%H:%M') }}
+                        {{ start.hour }}<span class=minute>:{{ start.strftime('%M') }}</span>
                     </time>
                 </th>
                 {% endif %}


### PR DESCRIPTION
Again, I'm bike-shedding. Feel free to ignore or reject this PR, you won't hurt my feelings. Otherwise this is WIP, comments questions and requests are all welcome.

EuroPython this year had a [flat schedule](https://ep2015.europython.eu/p3/schedule/ep2015/list/) page, as well as the [tabular schedule](https://ep2015.europython.eu/p3/schedule/ep2015/). I wanted to recreate it. This PR uses [wok hooks](http://wok.mythmon.com/docs/hooks/) to generate a flat version of the schedule, from the tabular schedule we already show.

![image](https://cloud.githubusercontent.com/assets/174450/9527611/18aa0bd4-4ce8-11e5-969f-873c520e966d.png)

If I've done it right then no changes (to schedule.rst, or to @zeth's workflow) are necessary - you get 2 schedule layouts for the price of one. You can see the markup in action at https://moreati.github.io/pyconuk.org/schedule/flat/ sans the styling, because the existing CSS uses absolute paths.
