### PR TITLE
Decrease size of mobile header

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -722,6 +722,14 @@ iframe {
   margin: 2em 0 0.5em 0;
   color: black;
 }
+.content h1:first-child,
+.content h2:first-child,
+.content h3:first-child,
+.content h4:first-child,
+.content h5:first-child,
+.content h6:first-child {
+  margin-top: 0em
+}
 .textblock dt {
   font-weight: bold;
   color: black;

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -509,33 +509,35 @@ iframe {
   display: block;
   overflow: hidden;
 }
-.page-head:before {
-  content: ' ';
-  display: block;
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 0.3125em;
-  background: white;
-}
 .page-head h1 {
-  display: block;
+  display: inline-block;
   font-size: 1em;
   margin: 0;
 }
 .page-head h1 a {
-  display: block;
+  display: inline-block;
+  color: white;
+  text-decoration: none;
+  text-transform: uppercase;
   overflow: hidden;
-  text-indent: -100em;
-  width: 4.8125em;
-  height: 6em;
-  background: url(../img/pycon-white.png);
-  background-size: cover;
-  margin: 1em 1em;
+  margin: 0.5em 1em;
   z-index: 999;
 }
 @media all and (min-width: 560px) {
+  .page-head:before {
+    content: ' ';
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 0.3125em;
+    background: white;
+  }
+  .page-head h1 {
+    display: block;
+  }
   .page-head h1 a {
+    display:block;
     position: absolute;
     margin: 0;
     left: 50%;
@@ -544,13 +546,14 @@ iframe {
     height: 12.5em;
     background: url(../img/pycon.png);
     background-size: cover;
+    text-indent: -100em;
   }
 }
 .page-head .menu-icon {
   position: relative;
   float: right;
   padding: 0.5em 0.5em 0.5em 1.5em;
-  margin: -7em 0.5em 0 0;
+  margin: 0em 0.5em 0 0;
   color: #2b2b2b;
   text-transform: uppercase;
   cursor: pointer;

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -708,10 +708,16 @@ iframe {
 }
 .textblock .huge {
   margin: 0.5em 0 0 0;
-  font-size: 6em;
+  font-size: 3em;
   text-transform: uppercase;
   text-align: center;
 }
+@media all and (min-width:560px) {
+  .textblock .huge {
+    font-size: 4.5em;
+  }
+}
+
 .textblock h1,
 .textblock h2,
 .textblock h3,


### PR DESCRIPTION
The site banner we use is not particularly tailored to narrow screens/smartphones. This improves it a bit. Before and after:

![image](https://cloud.githubusercontent.com/assets/174450/9567621/ab7fe728-4f2a-11e5-9fdb-0c8c9a0c69d6.png)
