### PR TITLE
Add the pylint sprint, which was missing from the initial commit

### DIFF
--- a/content/schedule.rst
+++ b/content/schedule.rst
@@ -453,6 +453,7 @@ Monday 21st September 2015
 |       | * `py.test sprint`_                                                  |
 |       | * `Romaine (BDD tool)`_                                              |
 |       | * MicroPython / BBC micro:bit                                        |
+|       | * `Pylint sprint`_                                                   |
 +-------+----------------------------------------------------------------------+
 | 12:30 | The Last Meal - we share a final meal of Fish and Chips together     |
 |       | (plus vegetarian options, etc)                                       |


### PR DESCRIPTION
Hi,

This PR adds the Pylint sprint, which seems to be missing from the initial commit in f1c4667f5e80875d557aad21a5b74b00011ae488.
