### PR TITLE
Replace Programme in the site menu with the flat schedule

### DIFF
--- a/content/schedule.rst
+++ b/content/schedule.rst
@@ -1,6 +1,6 @@
 type: page
 title: Schedule
-slug: schedule/tabular
+slug: schedule
 body_class_hack: talks
 ---
 
@@ -505,7 +505,7 @@ Notes
 .. |emsp| unicode:: U+2001
    :trim:
 
-.. _Flat: ../
+.. _Flat: flat/
 .. _Friday: `Friday 18th September 2015`_
 .. _Saturday: `Saturday 19th September 2015`_
 .. _Sunday: `Sunday 20th September 2015`_

--- a/content/schedule.rst
+++ b/content/schedule.rst
@@ -1,6 +1,6 @@
 type: page
 title: Schedule
-slug: schedule
+slug: schedule/tabular
 body_class_hack: talks
 ---
 
@@ -10,7 +10,18 @@ Schedule
 The dynamic conference for the leading dynamic language
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Jump to Friday_ |emsp| Saturday_ |emsp| Sunday_ |emsp| Monday_
+.. role:: active
+   :class: active
+
+.. container:: clearfix
+
+   .. class:: schedule-jump
+
+   Jump to Friday_ |emsp| Saturday_ |emsp| Sunday_ |emsp| Monday_
+
+   .. class:: schedule-switch
+
+   `Flat`_ |emsp| :active:`Tabular`
 
 Friday 18th September 2015
 --------------------------
@@ -494,6 +505,7 @@ Notes
 .. |emsp| unicode:: U+2001
    :trim:
 
+.. _Flat: ../
 .. _Friday: `Friday 18th September 2015`_
 .. _Saturday: `Saturday 19th September 2015`_
 .. _Sunday: `Sunday 20th September 2015`_

--- a/hooks/flat_schedule.py
+++ b/hooks/flat_schedule.py
@@ -323,7 +323,7 @@ def render_schedule(schedule, template_dir):
 def read_html_tabular_schedule(config):
     """Returns a list of events, from a Tabular HTML schedule
     """
-    tab_sched_dir = os.path.join(config['output_dir'], 'schedule')
+    tab_sched_dir = os.path.join(config['output_dir'], 'schedule', 'tabular')
     tab_sched_path = os.path.join(tab_sched_dir, 'index.html')
     tab_sched_etree = lxml.html.parse(tab_sched_path)
 
@@ -351,7 +351,7 @@ def mkdirs(path):
 
 def write_flat_schedule(schedule, config):
     schedule_html = render_schedule(schedule, config['template_dir'])
-    schedule_dir = os.path.join(config['output_dir'], 'schedule', 'flat')
+    schedule_dir = os.path.join(config['output_dir'], 'schedule')
     schedule_path = os.path.join(schedule_dir, 'index.html')
 
     mkdirs(schedule_dir)

--- a/hooks/flat_schedule.py
+++ b/hooks/flat_schedule.py
@@ -323,7 +323,7 @@ def render_schedule(schedule, template_dir):
 def read_html_tabular_schedule(config):
     """Returns a list of events, from a Tabular HTML schedule
     """
-    tab_sched_dir = os.path.join(config['output_dir'], 'schedule', 'tabular')
+    tab_sched_dir = os.path.join(config['output_dir'], 'schedule')
     tab_sched_path = os.path.join(tab_sched_dir, 'index.html')
     tab_sched_etree = lxml.html.parse(tab_sched_path)
 
@@ -351,7 +351,7 @@ def mkdirs(path):
 
 def write_flat_schedule(schedule, config):
     schedule_html = render_schedule(schedule, config['template_dir'])
-    schedule_dir = os.path.join(config['output_dir'], 'schedule')
+    schedule_dir = os.path.join(config['output_dir'], 'schedule', 'flat')
     schedule_path = os.path.join(schedule_dir, 'index.html')
 
     mkdirs(schedule_dir)

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -409,6 +409,15 @@ optgroup {
   font-weight: bold;
 }
 
+/* Clearfix
+   ========================================================================== */
+
+.clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
 /* Tables
    ========================================================================== */
 
@@ -802,7 +811,16 @@ iframe {
   width: 480px;
 }
 
-/* FLAT SCHEDULE */
+/* SCHEDULE */
+.schedule-jump {
+    float: left;
+}
+.schedule-switch {
+    float: right;
+}
+.schedule-switch .active {
+    font-weight: bold;
+}
 summary h2.day {
     display: inline-block;
     margin-top: 1em;

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
                     <ul>
-                        <li><a {% if page.title == "Schedule" %} class="active"{% endif %}href="/schedule/">Schedule</a></li>
+                        <li><a {% if page.title == "Schedule" %} class="active"{% endif %}href="/schedule/flat/">Schedule</a></li>
                         <li><a {% if page.title == "Venue" %} class="active"{% endif %}href="/venue/">Venue</a></li>
                         <li><a {% if page.title == "Sponsorship" %} class="active"{% endif %}href="/sponsorship/">Sponsor</a></li>
                         <li><a {% if page.title == "Science" %} class="active"{% endif %}href="/science/">Science</a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
                 <input type="checkbox" id="toggle-nav" class="hidden" />
                 <nav class="nav">
                     <ul>
-                        <li><a {% if page.title == "Programme" %} class="active"{% endif %}href="/programme/">Programme</a></li>
+                        <li><a {% if page.title == "Schedule" %} class="active"{% endif %}href="/schedule/">Schedule</a></li>
                         <li><a {% if page.title == "Venue" %} class="active"{% endif %}href="/venue/">Venue</a></li>
                         <li><a {% if page.title == "Sponsorship" %} class="active"{% endif %}href="/sponsorship/">Sponsor</a></li>
                         <li><a {% if page.title == "Science" %} class="active"{% endif %}href="/science/">Science</a></li>

--- a/templates/flat_schedule.html
+++ b/templates/flat_schedule.html
@@ -14,11 +14,21 @@
         <div class="column_content">
             <div class="textblock">
 
-<p>Jump to
-{% for day, events in schedule|groupby('day') %}
-<a href="#{{day|format_day_id}}">{{ day.strftime('%A') }}</a>&ensp;
-{% endfor %}
-</p>
+<div class="clearfix">
+    <p class="schedule-jump">
+        Jump to
+        {% for day, events in schedule|groupby('day') %}
+        <a href="#{{day|format_day_id}}">{{ day.strftime('%A') }}</a>
+        &ensp;
+        {% endfor %}
+    </p>
+    <p class="schedule-switch">
+        <span class=active>Flat</span>
+        &ensp;
+        <a href="tabular/">Tabular</a>
+    </p>
+</div>
+
 {% for day, events in schedule|groupby('day') %}
 <details class=day open>
     <summary>

--- a/templates/flat_schedule.html
+++ b/templates/flat_schedule.html
@@ -25,7 +25,7 @@
     <p class="schedule-switch">
         <span class=active>Flat</span>
         &ensp;
-        <a href="tabular/">Tabular</a>
+        <a href="../">Tabular</a>
     </p>
 </div>
 


### PR DESCRIPTION
Also
- Adds a switcher to choose between flat and tabular schedule
- Moves the flat schedule to /schedule/
- Moves the tabular schedule to /schedule/tabular

This means /programme/ is no longer reachable by an obvious link.
Given we're T - 10 days & only the lunchtime CfP remains - is that a problem?
