### PR TITLE
ics: use http:, not https:, for pyconuk.org links

### DIFF
--- a/hooks/flat_schedule.py
+++ b/hooks/flat_schedule.py
@@ -381,7 +381,7 @@ def write_ical_schedule(schedule, config):
         vevent.add('location').value = event['location']
 
         if event['href']:
-            href = 'https://www.pyconuk.org' + event['href']
+            href = 'http://www.pyconuk.org' + event['href']
 
             # TODO: convince clients to show text/html descriptions
             description = vevent.add('description')


### PR DESCRIPTION
Not only did I have a missing slash in the initial version, apparently I
didn't even re-test the links after adding it... Embarrassing, sorry.

cf #174 
