### PR TITLE
ics: Add explicit timezone

### DIFF
--- a/hooks/flat_schedule.py
+++ b/hooks/flat_schedule.py
@@ -10,6 +10,7 @@ import re
 import docutils.examples
 import jinja2
 import lxml.html
+import pytz
 import vobject
 #import yaml
 
@@ -363,13 +364,20 @@ def write_flat_schedule(schedule, config):
 def write_ical_schedule(schedule, config):
     cal = vobject.iCalendar()
     cal.add('x-wr-calname').value = 'PyCon UK 2015 Schedule'
+
+    def add_tz(dt):
+        # datetimes are in Europe/London time, but vobject blows up if we use
+        # pytz.timezone('Europe/London').localize(dt)
+        return pytz.UTC.localize(dt - datetime.timedelta(hours=1))
+
+
     for event in schedule:
         vevent = cal.add('vevent')
 
         if event['start']:
-            vevent.add('dtstart').value = event['start']
+            vevent.add('dtstart').value = add_tz(event['start'])
         if event['finish']:
-            vevent.add('dtend').value = event['finish']
+            vevent.add('dtend').value = add_tz(event['finish'])
 
         title = event['title']
         type_ = event['type']

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,12 @@ Jinja2==2.7.3
 LinkChecker==9.3
 lxml==3.4.4
 Markdown==2.1.1
+MarkupSafe==0.23
 py==1.4.27
 Pygments==1.4
 pytest==2.5.2
+python-dateutil==2.4.2
+pytz==2015.4
 PyYAML==3.10
 regex==2015.5.10
 requests==2.7.0


### PR DESCRIPTION
Fixes the problem described by @avengerpenguin on #174 where times are off by an hour.

Tested in Thunderbird, FastMail and GCal that the (now UTC) start and end times come out looking correct on my (Europe/London) computer. For the first two (the ones I use), this is exactly the same result as before, but for Google Calendar it makes the times right…

Static copy at http://wjt.me.uk/misc/schedule.ics as an example.
