### PR TITLE
POST-CONFERENCE: Holding text until 2016 site is live

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -10,7 +10,9 @@ title: Home
 <p>
 PyCon UK 2015 is over, thank you to everyone who contributed to making the conference such a huge success.
 We will be back in 2016, watch this space for developments!
+Until then, you can see some of the 2015 talks on our <a href="https://www.youtube.com/channel/UChA9XP_feY1-1oSy2L7acog">YouTube Channel</a>.
 </p>
+
 
 
 <hr />

--- a/content/index.html
+++ b/content/index.html
@@ -5,44 +5,13 @@ body_class_hack: home
 title: Home
 ---
 
-<h2>PyCon UK Returns!</h2>
+<h2>THANK YOU!</h2>
 
-<p>PyCon UK, the community organised conference for the Python programming
-language in the United Kingdom, returns on Friday 18th - Monday 21st
-September 2015.</p>
+<p>
+PyCon UK 2015 is over, thank you to everyone who contributed to making the conference such a huge success.
+We will be back in 2016, watch this space for developments!
+</p>
 
-<p>As last year, it will be held at the Coventry University Technology
-Centre and include the usual smörgåsbord of talks, tutorials,
-workshops and keynotes. As in previous years there will be the hugely
-popular social events too: a conference meal, a charity social event
-on Friday evening (in aid of Cancer Research UK) and the famous
-corridor track.</p>
-
-<p>For the fourth year in a row, there will be an education track - we
-look forward to welcoming teaching colleagues and the young
-Pythonistas of tomorrow. This time we will also be joined by
-DjangoGirls and Trans*Code - both of whom will be providing Python
-training for new members of our community.</p>
-
-<p>We're also very excited to announce a new string to our bow: the
-Scientific Python track for, er, Scientists who use Python. Be amazed
-at how Python is helping us learn about and understand the world
-around us.</p>
-
-<p>Finally, this year's PyCon UK will be tinged with sadness as we
-inevitably remember John Pinner, our illustrious conference chair and
-founder of PyCon UK who recently lost his fight with cancer. Our
-tribute to John will be to make this the best PyCon UK yet - and that
-can only happen with your support.</p>
-
-<p>If you'd like to contribute, volunteer or help in any other way with
-PyCon UK (which is completely organised by volunteers) then get in
-touch via the <a href="https://mail.python.org/mailman/listinfo/pyconuk">
-conference mailing list</a>.</p>
-
-<hr/>
-
-<p>Catch up with the <a href="/news">latest conference news</a>!</p>
 
 <hr />
 


### PR DESCRIPTION
This PR just replaces the text on the index page with some holding text until we can make the 2016 site live.
