### PR TITLE
Adds a link to the introductory slides used in the workshop

### DIFF
--- a/content/workshops/event-sourced-domain-models-in-python.md
+++ b/content/workshops/event-sourced-domain-models-in-python.md
@@ -18,6 +18,8 @@ body_class_hack: talks
 
  * Have the [workshop student materials](https://bitbucket.org/sixty-north/d5-workshop-exercises-student-material) installed from Bitbucket. Further instructions are to be found there.
 
+ * You can also look at the [introductory slides](http://sixty-north.com/blog/event-sourced-domain-models-in-python-at-pycon-uk) which were used in the workshop.
+
 #### Synopsis
 
 In first part of this workshop we explore how to implement rich domain models using plain-old Python objects which are completely independent of any particular persistence technology such as an object-relational mapper.  Domain models often embody the core value of software systems, so implementing models independently of - often ephemeral - technology choices is an important strategy for long-lived, high-value systems.


### PR DESCRIPTION
I'm not sure for how long the 2015 site will be live, but some of my workshop attendees have gone looking for links to my slides on the event page, which this PR adds.

As an aside, it would be really nice if these pages were permanent (i.e. they had '2015') somewhere in the URL, rather than being swept away every year.
